### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/code-quality-checks.yml
+++ b/.github/workflows/code-quality-checks.yml
@@ -1,5 +1,8 @@
 name: Code Quality Check
 
+permissions:
+  contents: read
+
 "on":
   push:
     branches:
@@ -21,4 +24,3 @@ jobs:
       - uses: chartboost/ruff-action@v1
         with:
           version: "0.11.9"
-


### PR DESCRIPTION
Potential fix for [https://github.com/dbluhm/async-selective-queue/security/code-scanning/2](https://github.com/dbluhm/async-selective-queue/security/code-scanning/2)

To fix the issue, we will add a `permissions` block at the workflow level to explicitly limit the permissions of the `GITHUB_TOKEN`. Since the workflow only performs code formatting and linting checks, it does not require write permissions. The minimal required permission is `contents: read`. This change will ensure that the workflow adheres to the principle of least privilege.

The `permissions` block will be added at the root level of the workflow, applying to all jobs within the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
